### PR TITLE
TOPLAP Athens updates

### DIFF
--- a/2024/satellite.html
+++ b/2024/satellite.html
@@ -90,7 +90,7 @@
 			'<div>MY _____ IS AN ECOSYSTEM (exhibition+)</div>'
 		]);
 		tableRow('schedule', [
-			'May 24',
+			'May 21',
 			'<a href="#corfu">Corfu, GR</a>',
 			'&nbsp;',
 			'<div>Live Coding concert</div>'
@@ -185,6 +185,31 @@
 			<p><b>Principal Contact</b>: <a href="mailto: melodyloveless@gmail.com">Melody Loveless</a>
 		`);
 
+		// CORFU
+		section('corfu', 'main-section');
+		horizontalLine('corfu');
+		heading('corfu', 'May 21 | Corfu, GR', 0);
+		html('corfu', `
+			<h4>TOPLAP Athens</h4>
+			</br>
+			<p><b>Date/Time</b>: May 21</p>
+			<p><b>Time</b>: 20:00-22:00 EET</p>
+			<p><b>Venue</b>: Sound Laboratory of PEARL, Department of Audiovisual Arts (AVARTS), Ionian University, Corfu, Greece</p>
+			<p><b>Youtube Streaming: </b><a href="https://www.youtube.com/watch?v=H1A3Alhu5MQ">AVARTS channel</a></p>
+			<p>PEARL (Performative Environment Art Research Lab) of the Department of Audiovisual Arts of the Ionian University and TOPLAP Athens present a networked live coding concert:</p>
+			<ul>
+			20:00-22:00 Telematic live coding performances in SuperCollider using OscGroups.
+
+			<b>Program</b>:
+			<ul>
+				<li>square duet (Giorgos Diapoulis, Kosmas Giannoutakis)</li>
+				<li>sine quartet camelCase (Penny Anastasopoulou, Vasilis Agiomyrgianakis, Kosmas Giannoutakis, Giorgos Diapoulis)</li>
+				<li>granular quartet camelCase (Penny Anastasopoulou, Vasilis Agiomyrgianakis, Kosmas Giannoutakis, Giorgos Diapoulis)</li>
+			</ul>
+			</ul>
+			<p><b>Organizing Committee</b>: <a href="mailto:zannos@gmail.com">Iannis Zannos</a>, Martin Carlé, Thanasis Epitideios.</p>  <p><b>Performers:</b> Vasilis Agiomyrgianakis, Georgios Diapoulis, Penny Anastasopoulou, Kosmas Giannoutakis</p>
+		`);
+
 		// TOPLAP
 		section('toplap', 'main-section');
 		horizontalLine('toplap');
@@ -200,25 +225,6 @@
 	 		<p><a href="https://eulerroom.com/">Slot signup page</a></p>
     			</br>
 			<p><b>Organizing Committee</b>: <a href="mailto:highharmonics@gmail.com">HighHarmonics</a>, Alex McClean</p>
-		`);
-
-		// CORFU
-		section('corfu', 'main-section');
-		horizontalLine('corfu');
-		heading('corfu', 'May 24 | Corfu, GR', 0);
-		html('corfu', `
-			<h4>TOPLAP Athens</h4>
-			</br>
-			<p><b>Date/Time</b>: May 24</p>
-			<p><b>Time</b>: 17:00-23:00 EET</p>
-			<p><b>Venue</b>: Polytechno Live House, Corfu Old Town, Corfu, Greece</p>
-			<p>TOPLAP Athens intends to participate in collaboration with the Department of Audiovisual Arts of the Ionian University with an online Live Coding concert. We will support the following participation formats:</p>
-			<ul>
-				<li>Remote shared coding on SuperCollider via OscGroups. We offer an OscGroups server, OscGroups clients compiled apps for Linux, Mac, Windows, and a SuperCollider library for broadcasting own code and evaluating code received from remote evaluations from other members of the group. (sc-hacks-redux).</li>
-				<li>Estuary.  We invite groups who intend to perform using Estuary or similar online platforms and would work with them to present their performance live at the venue in Corfu.</li>
-			</ul>
-			<p>An open call will be issued on Discord. The event will form part of the annual Festival of the Department of Audiovisual Arts of the Ionian University, and will be streamed live from the university’s Youtube channel.</p>
-			<p><b>Organizing Committee</b>: <a href="mailto:zannos@gmail.com">Iannis Zannos</a>, Vasilis Agiomyrgianakis, Georgios Diapoulis, Penny Anastasopoulou, and friends (TBA)</p>
 		`);
 
 		// LONDON


### PR DESCRIPTION
TOPLAP Athens event is moved for May 21.  On the ICLC satellite webpage our event is moved above the TOPLAP / Online event on May 24 (requires edit for May 25-26?), for calendar event consistency. 